### PR TITLE
Fix incorrect style application to component

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="streamlit-keyup",
-    version="0.2.2",
+    version="0.2.3",
     author="Zachary Blackwood",
     author_email="zachary@streamlit.io",
     description="Text input that renders on keyup",

--- a/src/st_keyup/frontend/index.html
+++ b/src/st_keyup/frontend/index.html
@@ -9,8 +9,8 @@
     <script src="./main.js"></script>
     <link rel="stylesheet" href="./style.css" />
   </head>
-  <body>
-    <div id="root">
+  <body id="root">
+    <div>
       <label id="label" for="text_input">This is a label</label>
       <div class="input">
         <input name="text_input" id="input_box" />

--- a/src/st_keyup/frontend/style.css
+++ b/src/st_keyup/frontend/style.css
@@ -1,3 +1,9 @@
+body {
+  -webkit-tap-highlight-color: var(--text-color);
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: var(--font);
+}
 label {
   font-family: var(--font);
   font-weight: 400;


### PR DESCRIPTION
This fixes the issues #30, #29 

All I did was make the body in the document the root so that the elements inside it correctly inherit the styles from the event which later are applied in style.css to the body itself.

Used to render like this:

![image](https://github.com/blackary/streamlit-keyup/assets/48023588/d2829ad7-67ca-49d0-b586-30b3f9a14130)

On my end, on my particular implementation of my dark theme, now renders like this:

![image](https://github.com/blackary/streamlit-keyup/assets/48023588/48023320-4cc3-4f1d-873e-69e016499166)
