### PR TITLE
GH-35: Fix not rendering w/ Streamlit 1.32.2

### DIFF
--- a/src/st_keyup/frontend/main.js
+++ b/src/st_keyup/frontend/main.js
@@ -90,11 +90,12 @@ function onRender(event) {
       input.onkeyup = onKeyUp
     }
 
+    // Render with the correct height
+    Streamlit.setFrameHeight(73)
+
     window.rendered = true
   }
 }
 
 Streamlit.events.addEventListener(Streamlit.RENDER_EVENT, onRender)
 Streamlit.setComponentReady()
-// Render with the correct height
-Streamlit.setFrameHeight(73)


### PR DESCRIPTION
This commit fixes the issue where the component was not rendering with Streamlit 1.32.2. The issue was that the `Streamlit.setFrameHeight(73)` was being called before the component was rendered. This commit moves the `Streamlit.setFrameHeight(73)` to the `onRender` function.

Fixes #35