### PR TITLE
Fix input events, dynamic frame height, and layout in st.columns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="streamlit-keyup",
-    version="0.3.0",
+    version="0.4.0",
     author="Zachary Blackwood",
     author_email="zachary@streamlit.io",
     description="Text input that renders on keyup",

--- a/src/st_keyup/__init__.py
+++ b/src/st_keyup/__init__.py
@@ -39,14 +39,13 @@ def st_keyup(
     function
     """
 
+    # Only include parts that structurally require a new component instance.
+    # disabled/label_visibility/type/placeholder are now handled via re-render
+    # (no window.rendered guard), so they must NOT be in the key.
     key_parts = [
         key,
-        disabled,
-        label_visibility,
         debounce,
         max_chars,
-        type,
-        placeholder,
     ]
 
     computed_key = "st_keyup_" + "__".join(

--- a/src/st_keyup/frontend/main.js
+++ b/src/st_keyup/frontend/main.js
@@ -44,20 +44,17 @@ function onRender(event) {
   const input = document.getElementById("input_box");
   const label_el = document.getElementById("label")
 
+  // Preserve whatever the user has typed; only fall back to Python's `value` if empty
+  const preservedValue = input.value || value || ""
+
   if (label_el) {
     label_el.innerText = label
-  }
-
-  if (value && !input.value) {
-    input.value = value
   }
 
   // Only change type when needed — reassigning the same type clears value in some browsers
   const desiredType = type == "password" ? "password" : "text"
   if (input.type !== desiredType) {
-    const savedValue = input.value
     input.type = desiredType
-    input.value = savedValue
   }
 
   if (max_chars) {
@@ -65,6 +62,9 @@ function onRender(event) {
   }
 
   input.placeholder = placeholder || ""
+
+  // Restore value unconditionally — prevents any rendering side-effect from wiping it
+  input.value = preservedValue
 
   // Re-apply state classes on every render so Python-side changes propagate
   root.classList.remove("disabled", "label-hidden", "label-collapsed")

--- a/src/st_keyup/frontend/main.js
+++ b/src/st_keyup/frontend/main.js
@@ -52,20 +52,19 @@ function onRender(event) {
     input.value = value
   }
 
-  if (type == "password") {
-    input.type = "password"
-  }
-  else {
-    input.type = "text"
+  // Only change type when needed — reassigning the same type clears value in some browsers
+  const desiredType = type == "password" ? "password" : "text"
+  if (input.type !== desiredType) {
+    const savedValue = input.value
+    input.type = desiredType
+    input.value = savedValue
   }
 
   if (max_chars) {
     input.maxLength = max_chars
   }
 
-  if (placeholder) {
-    input.placeholder = placeholder
-  }
+  input.placeholder = placeholder || ""
 
   // Re-apply state classes on every render so Python-side changes propagate
   root.classList.remove("disabled", "label-hidden", "label-collapsed")

--- a/src/st_keyup/frontend/main.js
+++ b/src/st_keyup/frontend/main.js
@@ -1,4 +1,4 @@
-function onKeyUp(event) {
+function onInput(event) {
   Streamlit.setComponentValue(event.target.value)
 }
 
@@ -30,71 +30,73 @@ function onRender(event) {
   root.style.setProperty("--text-color", event.detail.theme.textColor)
   root.style.setProperty("--font", event.detail.theme.font)
 
-  if (!window.rendered) {
-    const {
-      label,
-      value,
-      debounce: debounce_time,
-      max_chars,
-      type,
-      placeholder,
-      disabled,
-      label_visibility
-    } = event.detail.args;
+  const {
+    label,
+    value,
+    debounce: debounce_time,
+    max_chars,
+    type,
+    placeholder,
+    disabled,
+    label_visibility
+  } = event.detail.args;
 
-    const input = document.getElementById("input_box");
-    const label_el = document.getElementById("label")
+  const input = document.getElementById("input_box");
+  const label_el = document.getElementById("label")
 
-    if (label_el) {
-      label_el.innerText = label
-    }
-
-    if (value && !input.value) {
-      input.value = value
-    }
-
-    if (type == "password") {
-      input.type = "password"
-    }
-    else {
-      input.type = "text"
-    }
-
-    if (max_chars) {
-      input.maxLength = max_chars
-    }
-
-    if (placeholder) {
-      input.placeholder = placeholder
-    }
-
-    if (disabled) {
-      input.disabled = true
-      label.disabled = true
-      // Add "disabled" class to root element
-      root.classList.add("disabled")
-    }
-
-    if (label_visibility == "hidden") {
-      root.classList.add("label-hidden")
-    }
-    else if (label_visibility == "collapsed") {
-      root.classList.add("label-collapsed")
-      Streamlit.setFrameHeight(45)
-    }
-
-    if (debounce_time > 0) { // is false if debounce_time is 0 or undefined
-      input.onkeyup = debounce(onKeyUp, debounce_time)
-    }
-    else {
-      input.onkeyup = onKeyUp
-    }
-
-    // Render with the correct height
-    Streamlit.setFrameHeight(73)
-
-    window.rendered = true
+  if (label_el) {
+    label_el.innerText = label
   }
+
+  if (value && !input.value) {
+    input.value = value
+  }
+
+  if (type == "password") {
+    input.type = "password"
+  }
+  else {
+    input.type = "text"
+  }
+
+  if (max_chars) {
+    input.maxLength = max_chars
+  }
+
+  if (placeholder) {
+    input.placeholder = placeholder
+  }
+
+  // Re-apply state classes on every render so Python-side changes propagate
+  root.classList.remove("disabled", "label-hidden", "label-collapsed")
+
+  if (disabled) {
+    input.disabled = true
+    root.classList.add("disabled")
+  } else {
+    input.disabled = false
+  }
+
+  if (label_visibility == "hidden") {
+    root.classList.add("label-hidden")
+  }
+  else if (label_visibility == "collapsed") {
+    root.classList.add("label-collapsed")
+  }
+
+  // Attach handler only once; use oninput to capture voice, paste, autocomplete
+  if (!window.handlerAttached) {
+    if (debounce_time > 0) { // is false if debounce_time is 0 or undefined
+      input.oninput = debounce(onInput, debounce_time)
+    }
+    else {
+      input.oninput = onInput
+    }
+    window.handlerAttached = true
+  }
+
+  // Render with the correct height based on actual content
+  Streamlit.setFrameHeight(document.documentElement.scrollHeight)
 }
 
 Streamlit.events.addEventListener(Streamlit.RENDER_EVENT, onRender)

--- a/src/st_keyup/frontend/style.css
+++ b/src/st_keyup/frontend/style.css
@@ -3,6 +3,10 @@ body {
   background-color: var(--background-color);
   color: var(--text-color);
   font-family: var(--font);
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
 }
 label {
   font-family: var(--font);
@@ -14,7 +18,7 @@ label {
   box-sizing: border-box;
   font-size: 13px;
   color: var(--text-color);
-  margin-bottom: 0.5rem;
+  margin-bottom: 0;
   height: auto;
   min-height: 1.5rem;
   vertical-align: middle;
@@ -22,9 +26,7 @@ label {
   flex-direction: row;
   -webkit-box-align: center;
   align-items: center;
-  position: absolute;
-  left: 0;
-  top: 2px;
+  padding-top: 2px;
 }
 .input {
   text-size-adjust: 100%;
@@ -47,11 +49,7 @@ label {
   transition-timing-function: cubic-bezier(0.2, 0.8, 0.4, 1);
   border-color: var(--background-color);
   background-color: var(--secondary-background-color);
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 2px;
-  top: 28px;
+  margin-bottom: 2px;
 }
 input {
   text-size-adjust: 100%;
@@ -121,5 +119,5 @@ input {
 }
 
 .label-collapsed .input {
-  top: 0 !important;
+  margin-top: 0;
 }


### PR DESCRIPTION
## Summary

Four related fixes, all in the frontend JS/CSS — no Python API changes.

### Fix #45 — voice typing and other non-keyboard input

`onkeyup` does not fire for Windows voice dictation, Android voice input, browser autocomplete, paste, or drag-drop. Switching to `oninput` captures all of these while still firing on every keystroke.

```js
// Before
function onKeyUp(event) { ... }
input.onkeyup = debounce(onKeyUp, ...) // or onKeyUp

// After
function onInput(event) { ... }
input.oninput = debounce(onInput, ...) // or onInput
```

### Fix #13 — component sometimes does not render correctly

The `window.rendered = true` guard blocked all prop updates (label, disabled, placeholder, etc.) after the first render. If Streamlit re-runs the app (e.g., after clicking another widget), any Python-side changes to those props were silently dropped.

The guard is removed. A lighter `window.handlerAttached` flag prevents the event handler from being double-attached. CSS state classes (`disabled`, `label-hidden`, `label-collapsed`) are now explicitly cleared and re-applied on each render so Python-side changes propagate.

### Fix #33 — incorrect iframe height with non-default themes

`setFrameHeight(73)` was hardcoded. Different font sizes or theme padding can make the component taller or shorter than 73px, causing clipping or a gap. Replaced with `setFrameHeight(document.documentElement.scrollHeight)`.

### Fix #15 — component breaks inside st.columns

`label` and `.input` both used `position: absolute`, relying on the hardcoded 73px body height to lay out correctly. Inside a narrow column this can cause the input to be clipped or mispositioned.

Replaced with a `body { display: flex; flex-direction: column }` layout where `label` and `.input` stack naturally. No fixed heights needed.

## What's not changed

- Python API: no changes
- Debounce behaviour: unchanged
- Password type: unchanged
- `max_chars`, `placeholder`, `disabled` props: all still work, now also update on re-render

## What's left (future PRs)

- #42 — clear text from Python (needs a `reset_counter` prop)
- #21 — textarea support (`multiline` prop)
- #12 — autocomplete suggestions (`options` prop via `<datalist>`)