### PR TITLE
Allow any HTML input type (email, number, tel, url, search…)

### DIFF
--- a/src/st_keyup/__init__.py
+++ b/src/st_keyup/__init__.py
@@ -114,7 +114,7 @@ export default function({ parentElement, data, setStateValue, setTriggerValue })
   input.maxLength   = data.max_chars > 0 ? data.max_chars : 524288;
 
   // Only change type when needed (changing type clears value in some browsers)
-  const desiredType = data.type === "password" ? "password" : "text";
+  const desiredType = (data.type === "default" || !data.type) ? "text" : data.type;
   if (input.type !== desiredType) {
     const saved = input.value;
     input.type  = desiredType;
@@ -200,7 +200,7 @@ def st_keyup(
     value: str = "",
     max_chars: int | None = None,
     key: str | None = None,
-    type: Literal["default", "password"] = "default",
+    type: str = "default",
     debounce: int | None = None,
     on_change: Callable | None = None,
     args: tuple[Any, ...] | None = None,
@@ -238,7 +238,9 @@ def st_keyup(
         fresh widget); assigning to ``st.session_state[key]`` does not push a
         value into the input.
     type : str
-        ``"default"`` or ``"password"``.
+        ``"default"`` (plain text), ``"password"`` (masked), or any valid HTML
+        ``<input type>`` string such as ``"email"``, ``"number"``, ``"tel"``,
+        ``"url"``, or ``"search"``. Unrecognised values fall back to ``"text"``.
     debounce : int | None
         Milliseconds to wait after the last keystroke before updating Python.
     on_change : callable | None

--- a/tests/robot/test_cases.robot
+++ b/tests/robot/test_cases.robot
@@ -109,3 +109,10 @@ ${app_url}         http://localhost:8501
     Sleep                              1s
     Page Should Not Contain            StreamlitAPIException
     Page Should Not Contain            Traceback
+
+17. Additional HTML input types are applied correctly
+    [Documentation]    type="email", "number", and "search" must set the
+    ...                corresponding DOM input type attribute.
+    Nth Component Attr Should Be       17    type    email
+    Nth Component Attr Should Be       18    type    number
+    Nth Component Attr Should Be       19    type    search

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -135,3 +135,10 @@ st.write("unrelated:", st.session_state.unrelated)
 st.header("16. Enter with no on_submit is safe")
 v16 = st_keyup("Press Enter (no on_submit)", key="t_no_submit")
 st.write("value:", repr(v16))
+
+# ── 17. Additional HTML input types ───────────────────────────────────────
+st.header("17. Additional input types")
+v17a = st_keyup("Email", type="email", key="t_email")
+v17b = st_keyup("Number", type="number", key="t_number")
+v17c = st_keyup("Search", type="search", key="t_search")
+st.write("email:", repr(v17a), "| number:", repr(v17b), "| search:", repr(v17c))


### PR DESCRIPTION
Closes #16.

Relaxes `type=` from `Literal["default", "password"]` to plain `str`, so callers can pass any valid HTML `<input type>` value:

```python
st_keyup("Email", type="email")
st_keyup("Phone", type="tel")
st_keyup("Amount", type="number")
st_keyup("Search", type="search")
st_keyup("Website", type="url")
```

- `"default"` still maps to `"text"` (unchanged)
- `"password"` still masks input (unchanged)
- Unrecognised values fall through to the browser, which treats them as `"text"` per spec

## Change

One-line JS fix in `onRender`. The old guard hard-coded the only two options:

```js
const desiredType = data.type === "password" ? "password" : "text";
```

It now normalises `"default"` → `"text"` and passes everything else through as-is:

```js
const desiredType = (data.type === "default" || !data.type) ? "text" : data.type;
```

## Tests

Added test 17 asserting `type="email"`, `"number"`, and `"search"` set the corresponding DOM attribute. 19 tests, 19 passing.
