### PR TITLE
Add optional inline clear button (show_clear=False)

### DIFF
--- a/src/st_keyup/__init__.py
+++ b/src/st_keyup/__init__.py
@@ -15,6 +15,7 @@ _HTML = """
   <label id="label" class="stkeyup__label"></label>
   <div class="stkeyup__wrap" id="wrap">
     <input id="input" class="stkeyup__input" />
+    <button id="clear-btn" class="stkeyup__clear" aria-label="Clear">&#x2715;</button>
   </div>
 </div>
 """
@@ -81,6 +82,30 @@ _CSS = """
   cursor: not-allowed;
   opacity: 0.5;
 }
+
+/* inline clear button */
+.stkeyup__clear {
+  display: none;   /* shown by JS when show_clear=True and value non-empty */
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-right: 6px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--st-text-color, inherit);
+  opacity: 0.5;
+  font-size: 14px;
+  line-height: 1;
+}
+.stkeyup__clear:hover {
+  opacity: 1;
+  background: rgba(127, 127, 127, 0.15);
+}
 """
 
 # ---------------------------------------------------------------------------
@@ -89,10 +114,11 @@ _CSS = """
 
 _JS = r"""
 export default function({ parentElement, data, setStateValue, setTriggerValue }) {
-  const root  = parentElement.querySelector("#root");
-  const lbl   = parentElement.querySelector("#label");
-  const wrap  = parentElement.querySelector("#wrap");
-  const input = parentElement.querySelector("#input");
+  const root     = parentElement.querySelector("#root");
+  const lbl      = parentElement.querySelector("#label");
+  const wrap     = parentElement.querySelector("#wrap");
+  const input    = parentElement.querySelector("#input");
+  const clearBtn = parentElement.querySelector("#clear-btn");
 
   // ── Update label ─────────────────────────────────────────────────────────
   lbl.textContent = data.label ?? "";
@@ -137,8 +163,13 @@ export default function({ parentElement, data, setStateValue, setTriggerValue })
   }
 
   // ── Store latest render values for use in the handlers ────────────────────
-  parentElement._debounce = data.debounce ?? 0;
-  parentElement._hasSubmit = !!data.has_submit;
+  parentElement._debounce   = data.debounce ?? 0;
+  parentElement._hasSubmit  = !!data.has_submit;
+  parentElement._showClear  = !!data.show_clear;
+
+  // ── Clear button visibility ───────────────────────────────────────────────
+  clearBtn.style.display =
+    (parentElement._showClear && input.value !== "") ? "flex" : "none";
 
   // ── Attach handlers once ──────────────────────────────────────────────────
   if (!parentElement._attached) {
@@ -146,6 +177,9 @@ export default function({ parentElement, data, setStateValue, setTriggerValue })
 
     input.addEventListener("input", () => {
       input._userTyping = true;
+      // Update clear button visibility on each keystroke.
+      clearBtn.style.display =
+        (parentElement._showClear && input.value !== "") ? "flex" : "none";
       clearTimeout(debounceTimer);
       const delay = parentElement._debounce;
       if (delay > 0) {
@@ -158,6 +192,16 @@ export default function({ parentElement, data, setStateValue, setTriggerValue })
       // _userTyping is cleared in onRender once Python echoes the value back,
       // never on a timer — a timer can expire before the round-trip completes
       // and let an unrelated re-render stomp the user's input.
+    });
+
+    clearBtn.addEventListener("click", (e) => {
+      e.preventDefault();
+      input.value = "";
+      input._userTyping = false;
+      clearBtn.style.display = "none";
+      clearTimeout(debounceTimer);
+      setStateValue("value", "");
+      input.focus();
     });
 
     input.addEventListener("keydown", (e) => {
@@ -209,6 +253,7 @@ def st_keyup(
     placeholder: str = "",
     disabled: bool = False,
     label_visibility: Literal["visible", "hidden", "collapsed"] = "visible",
+    show_clear: bool = False,
     on_submit: Callable | None = None,
     submit_args: tuple[Any, ...] | None = None,
     submit_kwargs: dict[str, Any] | None = None,
@@ -255,6 +300,9 @@ def st_keyup(
         When True, the input is rendered as disabled.
     label_visibility : str
         One of ``"visible"`` (default), ``"hidden"``, or ``"collapsed"``.
+    show_clear : bool
+        When True, a small × button appears inside the input whenever it is
+        non-empty. Clicking it clears the field and fires ``on_change`` if set.
     on_submit : callable | None
         Callback fired when the user presses Enter.
     submit_args : tuple | None
@@ -316,6 +364,7 @@ def st_keyup(
             "placeholder": placeholder,
             "disabled": disabled,
             "label_visibility": label_visibility,
+            "show_clear": show_clear,
             "has_submit": _on_submit is not None,
         },
         default={"value": current_value},

--- a/tests/robot/test_cases.robot
+++ b/tests/robot/test_cases.robot
@@ -83,29 +83,45 @@ ${app_url}         http://localhost:8501
     Wait Until Page Contains           Type: str    timeout=15s
     Page Should Not Contain            _WriteThrough
 
+13b. Inline clear button clears the field
+    [Documentation]    With show_clear=True, a × button appears when the input
+    ...                is non-empty and clicking it clears the value.
+    Type Into Component                14    to be cleared
+    Wait Until Page Contains           'to be cleared'    timeout=15s
+    ${visible}=    Execute Javascript
+    ...    var h = document.querySelectorAll("[data-testid='stBidiComponentIsolated']")[14];
+    ...    var btn = h.shadowRoot.querySelector("#clear-btn");
+    ...    return getComputedStyle(btn).display;
+    Should Be Equal    ${visible}    flex
+    Execute Javascript
+    ...    var h = document.querySelectorAll("[data-testid='stBidiComponentIsolated']")[14];
+    ...    h.shadowRoot.querySelector("#clear-btn").click();
+    Wait Until Page Contains           ''    timeout=15s
+    Nth Component Value Should Be      14    ${EMPTY}
+
 14. Unkeyed component round-trips to Python
     [Documentation]    A component with key=None must still send its value to
     ...                Python and must not raise.
-    Type Into Component                14    no key here
+    Type Into Component                15    no key here
     Wait Until Page Contains           'no key here'    timeout=15s
-    Nth Component Value Should Be      14    no key here
+    Nth Component Value Should Be      15    no key here
     Page Should Not Contain            Traceback
 
 15. Unrelated rerun does not stomp typed input
     [Documentation]    Typing then triggering an unrelated rerun must NOT
     ...                clear or reset the user's input.
-    Type Into Component                15    must survive
+    Type Into Component                16    must survive
     Wait Until Page Contains           'must survive'    timeout=15s
     Click Element                      xpath=//button[normalize-space()='Unrelated rerun']
     Wait Until Page Contains           unrelated: 1    timeout=15s
-    Nth Component Value Should Be      15    must survive
+    Nth Component Value Should Be      16    must survive
 
 16. Enter key without on_submit raises no exception
     [Documentation]    Pressing Enter in a component with no on_submit
     ...                must not raise a StreamlitAPIException.
-    Type Into Component                16    enter safe
+    Type Into Component                17    enter safe
     Wait Until Page Contains           'enter safe'    timeout=15s
-    Press Enter In Component           16
+    Press Enter In Component           17
     Sleep                              1s
     Page Should Not Contain            StreamlitAPIException
     Page Should Not Contain            Traceback

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -110,6 +110,11 @@ if st.button("Reset the field above"):
     st.session_state.clear_gen += 1
     st.rerun()
 
+# ── 12b. Inline clear button ───────────────────────────────────────────────
+st.header("12b. Clear button")
+v12b = st_keyup("Type then click ×", show_clear=True, key="t_show_clear")
+st.write("value:", repr(v12b))
+
 # ── 13. Session state shape ────────────────────────────────────────────────
 st.header("13. Session state introspection")
 ss_val = st.session_state.get("t_basic")


### PR DESCRIPTION
Closes #42.

Adds an optional `show_clear` parameter. When `True`, a small × button appears inside the input whenever it is non-empty:

```python
st_keyup("Search", show_clear=True)
```

- Hidden by default (`show_clear=False`) — no behaviour change for existing users
- Clicking clears the field immediately, bypassing any `debounce` delay
- Fires `on_change` so Python is notified of the cleared value
- Styled with the theme's `--st-*` custom properties, so it follows light/dark mode

## Change

A `<button>` inside the input wrapper, hidden via CSS by default. `onRender` and the `input` event handler toggle its visibility based on `show_clear` and whether the value is empty. The click handler clears the value, cancels any pending debounce timer, notifies Python, and returns focus to the input.

## Tests

Added test 13b: types a value, asserts the button becomes visible, clicks it, and asserts the field is empty. 19 tests, 19 passing.
